### PR TITLE
Added account balance null-safety and validate amounts

### DIFF
--- a/bank/bank/src/main/java/com/nkm/bank/service/AccountServiceImpl.java
+++ b/bank/bank/src/main/java/com/nkm/bank/service/AccountServiceImpl.java
@@ -17,6 +17,10 @@ public class AccountServiceImpl implements AccountService{
 
     @Override
     public Account createAccount(Account account) {
+        // Ensure a null balance is initialized to 0.0 to avoid NPE later
+        if (account.getAccount_balance() == null) {
+            account.setAccount_balance(0.0);
+        }
         Account account_saved = repo.save(account);
         return account_saved;
     }
@@ -39,12 +43,15 @@ public class AccountServiceImpl implements AccountService{
 
     @Override
     public Account depositAmount(Long accountNumber, Double amount) {
+        if (amount == null || amount <= 0) throw new IllegalArgumentException("Deposit amount must be positive");
         Optional<Account> account = repo.findById(accountNumber);
-        if(account.isEmpty()){
+        if (account.isEmpty()){
             throw new RuntimeException("Account is not present");
         }
-        Account accountPresent=account.get();
-        Double totalBalance= accountPresent.getAccount_balance()+amount;
+        Account accountPresent = account.get();
+        Double current = accountPresent.getAccount_balance();
+        if (current == null) current = 0.0;
+        Double totalBalance = current + amount;
         accountPresent.setAccount_balance(totalBalance);
         repo.save(accountPresent);
         return accountPresent;
@@ -53,12 +60,16 @@ public class AccountServiceImpl implements AccountService{
     }
     @Override
     public Account withdrawAmount(Long accountNumber, Double amount){
+        if (amount == null || amount <= 0) throw new IllegalArgumentException("Withdraw amount must be positive");
         Optional<Account> account = repo.findById(accountNumber);
-        if(account.isEmpty()){
+        if (account.isEmpty()){
             throw new RuntimeException("Account is not present");
         }
-        Account accountPresent=account.get();
-        Double accountBalance= accountPresent.getAccount_balance()-amount;
+        Account accountPresent = account.get();
+        Double current = accountPresent.getAccount_balance();
+        if (current == null) current = 0.0;
+        Double accountBalance = current - amount;
+        if (accountBalance < 0) throw new RuntimeException("Insufficient balance");
         accountPresent.setAccount_balance(accountBalance);
         repo.save(accountPresent);
         return accountPresent;


### PR DESCRIPTION
What changed
- AccountServiceImpl.java
- Initialize null account_balance to 0.0 in createAccount.
- In depositAmount treat a null current balance as 0.0, validate deposit amount is positive, and update balance safely.
- In withdrawAmount treat a null current balance as 0.0, validate withdraw amount is positive, and throw on insufficient funds.

Why
- The account_balance field is a Double and can be null. Previously arithmetic like current + amount could cause NullPointerExceptions.
- Adding validation improves robustness and gives clearer error behavior for invalid inputs (negative/zero amounts, overdrafts).