### PR TITLE
Added README.md to get started with the application

### DIFF
--- a/bank/bank/README.md
+++ b/bank/bank/README.md
@@ -1,0 +1,28 @@
+# Get started
+
+This short guide shows how to get the application running locally:
+
+1) Open PowerShell and go to the bank module folder:
+
+2) Start MongoDB locally if you want to use the bundled configuration. If you don't have Mongo, you can still run the app but some features that persist data will not work.
+
+3) Build and run the app using the Maven wrapper:
+
+```powershell
+.\mvnw.cmd clean package
+.\mvnw.cmd spring-boot:run
+```
+
+4) Open a browser or API client and visit:
+
+- http://localhost:8080
+
+Useful endpoints:
+
+- Create account: POST /account/create
+- Get account: GET /account/{accountNumber}
+- Deposit: PUT /account/deposit/{accountNumber}/{amount}
+
+Notes
+- Default MongoDB connection is set in `src/main/resources/application.properties`.
+- Run the `spring-boot:run` step and you should see the application start on port 8080.


### PR DESCRIPTION
- Added a concise, Get Started README for the bank application
- File added: README.md
- Provides one-step instructions to build and run the application locally (uses the Maven wrapper), and a few useful endpoints for quick smoke tests.
- Aim: make it easier for new contributors to run the service without diving into configuration details.